### PR TITLE
Add environment variable mappings for options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,19 @@
 
 **Topics**
 
+- <a href="#v1-0-1">v1\.0\.1</a>
+    - <a href="#minor-changes">Minor Changes</a>
 - <a href="#v1-0-0">v1\.0\.0</a>
     - <a href="#release-summary">Release Summary</a>
-    - <a href="#minor-changes">Minor Changes</a>
+    - <a href="#minor-changes-1">Minor Changes</a>
+
+<a id="v1-0-1"></a>
+## v1\.0\.1
+
+<a id="minor-changes"></a>
+### Minor Changes
+
+* inventory \- Added environment variable option for <code>db\_host</code>\, <code>db\_port</code>\, <code>db\_user</code>\, <code>db\_password</code>\, and <code>db\_name</code> options\.
 
 <a id="v1-0-0"></a>
 ## v1\.0\.0
@@ -14,7 +24,7 @@
 
 Initial release of the silexdata\.mysql Ansible Collection\.
 
-<a id="minor-changes"></a>
+<a id="minor-changes-1"></a>
 ### Minor Changes
 
 * Added an inventory plugin for MySQL\.

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -12,3 +12,11 @@ releases:
     fragments:
       - 1.0.0.yml
     release_date: '2025-08-15'
+  1.0.1:
+    changes:
+      minor_changes:
+        - inventory - Added environment variable option for ``db_host``, ``db_port``,
+          ``db_user``, ``db_password``, and ``db_name`` options.
+    fragments:
+      - 20250909-add-env-var-options.yml
+    release_date: '2025-09-09'

--- a/plugins/inventory/inventory.py
+++ b/plugins/inventory/inventory.py
@@ -32,27 +32,37 @@ options:
   db_host:
     description:
       - Database host
+    env:
+      - name: MYSQL_INVENTORY_DB_HOST
     required: true
     type: str
   db_port:
     description:
       - Database port
+    env:
+      - name: MYSQL_INVENTORY_DB_PORT
     required: false
     default: 3306
     type: int
   db_user:
     description:
       - Database user
+    env:
+      - name: MYSQL_INVENTORY_DB_USER
     required: true
     type: str
   db_password:
     description:
       - Database password
+    env:
+      - name: MYSQL_INVENTORY_DB_PASSWORD
     required: true
     type: str
   db_name:
     description:
       - Database name
+    env:
+      - name: MYSQL_INVENTORY_DB_NAME
     required: true
     type: str
   db_query:
@@ -159,6 +169,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if not isinstance(query, str) or not query.strip():
             error = "Query must be a non-empty string"
             display.error(error)
+
             raise AnsibleError(error)
         if not query.strip().upper().startswith("SELECT"):
             error = "Database query must be a valid SELECT statement"
@@ -174,6 +185,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 database=self.get_option("db_name"),
                 cursorclass=pymysql.cursors.DictCursor,
             )
+
             display.vv(
                 f"Connected to database: {self.get_option('db_name')} on {self.get_option('db_host')}"
             )


### PR DESCRIPTION
Added environment variable mappings for the following options:

`db_host` - `MYSQL_INVENTORY_DB_HOST`
`db_port` - `MYSQL_INVENTORY_DB_PORT`
`db_user` - `MYSQL_INVENTORY_DB_USER`
`db_password` - `MYSQL_INVENTORY_DB_PASSWORD`
`db_name` - `MYSQL_INVENTORY_DB_NAME`